### PR TITLE
Fix include for Non-Unity Build.

### DIFF
--- a/ACLPlugin/Source/ACLPlugin/Private/ACLStatsDumpCommandlet.cpp
+++ b/ACLPlugin/Source/ACLPlugin/Private/ACLStatsDumpCommandlet.cpp
@@ -27,6 +27,7 @@
 #if WITH_EDITOR
 #include "Runtime/Core/Public/HAL/FileManagerGeneric.h"
 #include "Runtime/Core/Public/HAL/PlatformTime.h"
+#include "Runtime/CoreUObject/Public/UObject/UObjectIterator.h"
 #include "Runtime/Engine/Classes/Animation/AnimCompress_Automatic.h"
 #include "Runtime/Engine/Classes/Animation/Skeleton.h"
 #include "Runtime/Engine/Public/AnimationCompression.h"
@@ -43,6 +44,7 @@
 #include <acl/io/clip_reader.h>
 #include <acl/math/quat_32.h>
 #include <acl/math/transform_32.h>
+
 
 // Commandlet example inspired by: https://github.com/ue4plugins/CommandletPlugin
 // To run the commandlet, add to the commandline: "$(SolutionDir)$(ProjectName).uproject" -run=/Script/ACLPlugin.ACLStatsDump "-acl=<path/to/raw/acl/sjson/files/directory>" "-stats=<path/to/output/stats/directory>"

--- a/ACLPlugin/Source/ACLPlugin/Private/AnimCompress_ACL.cpp
+++ b/ACLPlugin/Source/ACLPlugin/Private/AnimCompress_ACL.cpp
@@ -26,6 +26,7 @@
 #include "Animation/AnimEncodingRegistry.h"
 
 #if WITH_EDITOR
+#include "AnimationCompression.h"
 #include "ACLImpl.h"
 
 #include <acl/algorithm/uniformly_sampled/encoder.h>

--- a/ACLPlugin/Source/ACLPlugin/Private/AnimCompress_ACLCustom.cpp
+++ b/ACLPlugin/Source/ACLPlugin/Private/AnimCompress_ACLCustom.cpp
@@ -25,6 +25,19 @@
 #include "AnimCompress_ACLCustom.h"
 #include "Animation/AnimEncodingRegistry.h"
 
+#if WITH_EDITOR
+#include "AnimationCompression.h"
+#include "ACLImpl.h"
+
+#include <acl/algorithm/uniformly_sampled/encoder.h>
+#include <acl/algorithm/uniformly_sampled/decoder.h>
+#include <acl/compression/skeleton_error_metric.h>
+#include <acl/compression/utils.h>
+
+#include <sjson/writer.h>
+#include <acl/io/clip_writer.h>
+#endif
+
 UAnimCompress_ACLCustom::UAnimCompress_ACLCustom(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {


### PR DESCRIPTION
Fix the compilation when you build Unreal with the plugin in 'Non-Unity' mode.