### PR TITLE
Allow a recompression if we have change/add/remove KeyEndEffectorsMatchNameArray.

### DIFF
--- a/ACLPlugin/Source/ACLPlugin/Private/AnimCompress_ACL.cpp
+++ b/ACLPlugin/Source/ACLPlugin/Private/AnimCompress_ACL.cpp
@@ -184,6 +184,7 @@ void UAnimCompress_ACL::PopulateDDCKey(FArchive& Ar)
 
 	uint32 ForceRebuildVersion = 1;
 	uint16 AlgorithmVersion = get_algorithm_version(AlgorithmType8::UniformlySampled);
+	uint32 SettingsHash = Settings.get_hash();
 	uint32 KeyEndEffectorsHash = 0;
 
 	for (const FString& MatchName : UAnimationSettings::Get()->KeyEndEffectorsMatchNameArray)

--- a/ACLPlugin/Source/ACLPlugin/Private/AnimCompress_ACL.cpp
+++ b/ACLPlugin/Source/ACLPlugin/Private/AnimCompress_ACL.cpp
@@ -184,14 +184,14 @@ void UAnimCompress_ACL::PopulateDDCKey(FArchive& Ar)
 
 	uint32 ForceRebuildVersion = 1;
 	uint16 AlgorithmVersion = get_algorithm_version(AlgorithmType8::UniformlySampled);
-	uint32 SettingsHash = Settings.get_hash();
-	
+	uint32 KeyEndEffectorsHash = 0;
+
 	for (const FString& MatchName : UAnimationSettings::Get()->KeyEndEffectorsMatchNameArray)
 	{
-		SettingsHash = hash_combine(SettingsHash, GetTypeHash(MatchName));
+		KeyEndEffectorsHash = hash_combine(KeyEndEffectorsHash, GetTypeHash(MatchName));
 	}
 	
 	Ar	<< SafetyFallbackThreshold << ErrorThreshold << DefaultVirtualVertexDistance << SafeVirtualVertexDistance
-		<< ForceRebuildVersion << AlgorithmVersion << SettingsHash;
+		<< ForceRebuildVersion << AlgorithmVersion << SettingsHash << KeyEndEffectorsHash;
 }
 #endif // WITH_EDITOR

--- a/ACLPlugin/Source/ACLPlugin/Private/AnimCompress_ACL.cpp
+++ b/ACLPlugin/Source/ACLPlugin/Private/AnimCompress_ACL.cpp
@@ -27,6 +27,7 @@
 
 #if WITH_EDITOR
 #include "AnimationCompression.h"
+#include "Animation/AnimationSettings.h"
 #include "ACLImpl.h"
 
 #include <acl/algorithm/uniformly_sampled/encoder.h>
@@ -184,7 +185,12 @@ void UAnimCompress_ACL::PopulateDDCKey(FArchive& Ar)
 	uint32 ForceRebuildVersion = 1;
 	uint16 AlgorithmVersion = get_algorithm_version(AlgorithmType8::UniformlySampled);
 	uint32 SettingsHash = Settings.get_hash();
-
+	
+	for (const FString& MatchName : UAnimationSettings::Get()->KeyEndEffectorsMatchNameArray)
+	{
+		SettingsHash = hash_combine(SettingsHash, GetTypeHash(MatchName));
+	}
+	
 	Ar	<< SafetyFallbackThreshold << ErrorThreshold << DefaultVirtualVertexDistance << SafeVirtualVertexDistance
 		<< ForceRebuildVersion << AlgorithmVersion << SettingsHash;
 }


### PR DESCRIPTION
Currently we sadly need to change a parameter of the compression setting or edit the ForceRebuildVersion for recompress when we edit the KeyEndEffectorsMatchNameArray. So I simply add all bone name to the hash. It is a hash without case sensentive for the bone name.