### PR TITLE
fix(database): properly stream in the bulk data at the right offset

### DIFF
--- a/ACLPlugin/Source/ACLPlugin/Private/UE4DatabaseStreamer.h
+++ b/ACLPlugin/Source/ACLPlugin/Private/UE4DatabaseStreamer.h
@@ -107,9 +107,13 @@ public:
 		}
 
 		// Fire off our async streaming request
-		const uint32 BulkDataOffset = Tier == acl::quality_tier::medium_importance ? 0 : BulkDataSize[0];
-		uint8* BulkDataPtr = BulkData[TierIndex];
-		PendingIORequest = StreamableBulkData.CreateStreamingRequest(BulkDataOffset + Offset, Size, AIOP_Low, &AsyncFileCallBack, BulkDataPtr);
+		const uint32 BulkDataTierStartOffset = Tier == acl::quality_tier::medium_importance ? 0 : BulkDataSize[0];
+		const uint64 BulkDataReadOffset = BulkDataTierStartOffset + Offset;
+
+		uint8* StreamedBulkDataPtr = BulkData[TierIndex];
+		uint8* DestBulkDataPtr = StreamedBulkDataPtr + Offset;
+
+		PendingIORequest = StreamableBulkData.CreateStreamingRequest(BulkDataReadOffset, Size, AIOP_Low, &AsyncFileCallBack, DestBulkDataPtr);
 		if (PendingIORequest == nullptr)
 		{
 			UE_LOG(LogAnimationCompression, Warning, TEXT("ACL failed to initiate database stream in request!"));


### PR DESCRIPTION
When multiple chunks are present and multiple requests are required,
we must not only offset into the bulk data on disk but also into the
bulk data in memory.

Fixes #85