### PR TITLE
fix: set correct additive format to fix incorrect scale

### DIFF
--- a/ACLPlugin/Source/ACLPlugin/Private/AnimBoneCompressionCodec_ACLBase.cpp
+++ b/ACLPlugin/Source/ACLPlugin/Private/AnimBoneCompressionCodec_ACLBase.cpp
@@ -366,7 +366,7 @@ bool UAnimBoneCompressionCodec_ACLBase::Compress(const FCompressibleAnimData& Co
 		Settings.error_metric = &DefaultErrorMetric;
 	}
 
-	const acl::additive_clip_format8 AdditiveFormat = acl::additive_clip_format8::additive0;
+	const acl::additive_clip_format8 AdditiveFormat = acl::additive_clip_format8::additive1;
 
 	acl::output_stats Stats;
 	acl::compressed_tracks* CompressedTracks = nullptr;


### PR DESCRIPTION
As documented [here](https://github.com/nfrechette/acl/blob/develop/docs/additive_clips.md). We should use `additive1` instead of `additive0` in UE. Otherwise the animated mesh would appear as about twice large as it should be (due to incorrect scale calculation as implied by `additive0` format).